### PR TITLE
fix(windy-service): 修复创建应用的时候提示Git配置不存在问题

### DIFF
--- a/windy-console/windy-service/src/main/java/com/zj/service/service/MicroserviceService.java
+++ b/windy-console/windy-service/src/main/java/com/zj/service/service/MicroserviceService.java
@@ -106,7 +106,10 @@ public class MicroserviceService {
     }
 
     private IGitRepositoryHandler getRepositoryBranch(String type) {
-        return repositoryBranches.stream().filter(repository -> Objects.equals(repository.gitType(), type)).findAny().orElse(null);
+        if (StringUtils.isBlank(type)) {
+            return null;
+        }
+        return repositoryBranches.stream().filter(repository -> type.equalsIgnoreCase(repository.gitType())).findAny().orElse(null);
     }
 
     public PageSize<ServiceDto> getServices(Integer pageNo, Integer size, String name) {


### PR DESCRIPTION
策略选择仓库处理类的时候Type匹配字段没有忽略大小写导致找不到对应处理类

Closes https://github.com/languyue/Windy/issues/18